### PR TITLE
cloud-init ssh_pwauth=true

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -199,6 +199,16 @@
     - dc-9-users
     - dc-9-users-ssh
 
+- name: Add cloud-init special config
+  copy:
+    content: |
+      ssh_pwauth: true
+    dest: /etc/cloud/cloud.cfg.d/99_specialconfig.cfg
+  tags:
+    - dc-9
+    - dc-9-users
+    - dc-9-users-ssh
+
 - name: Reload ssh
   systemd:
     name: sshd


### PR DESCRIPTION
Closes #1 . Cloud-init was overwriting sshd_config