### PR TITLE
Autoinstall pip requirements and added become flags inside the role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 playbook
+private/

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,11 +1,13 @@
 ---
 # handlers file for DC-9
 - name: Save iptables rules
+  become: yes
   shell: iptables-save > /etc/sysconfig/iptables
   tags:
     - always
 
 - name: Restart iptables
+  become: yes
   systemd:
     name: iptables
     state: started

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,7 @@
       - mod_php
       - mariadb-server
       - php-mysql
+      - python3
       - python3-pip
       - iptables-services
       - http://li.nux.ro/download/nux/dextop/el7Server/x86_64/knock-server-0.7-1.el7.nux.x86_64.rpm
@@ -18,7 +19,19 @@
     - dc-9-packages
     - dc-9-packages-install
 
+- name: Install pip dependencies
+  become: yes
+  pip:
+   name:
+   - PyMySQL
+   - pyinstaller
+  tags:
+    - dc-9
+    - dc-9-packages
+    - dc-9-packages-install
+
 - name: Configure packages
+  become: yes
   template:
     src: '{{ pkg.src }}'
     dest: '{{ pkg.dest }}'
@@ -36,6 +49,7 @@
     - dc-9-packages-config
 
 - name: Set mariadb localhost address binding
+  become: yes
   ini_file:
     path: /etc/my.cnf
     section: mysqld
@@ -49,6 +63,7 @@
     - dc-9-packages-config-mariadb
 
 - name: Set iptables rules for SSH + PortKnocking
+  become: yes
   iptables:
     comment: '{{ rule.comment }}'
     chain: '{{ rule.chain }}'
@@ -74,6 +89,7 @@
     - dc-9-packages-config-knockd
 
 - name: Enable and start httpd, mariadb and knockd
+  become: yes
   systemd:
     name: '{{ service }}'
     state: restarted
@@ -90,6 +106,7 @@
     - dc-9-packages-systemd
 
 - name: Deploy web
+  become: yes
   unarchive:
     src: html.tar.gz
     dest: /var/www/html
@@ -102,6 +119,7 @@
     - dc-9-web-source
 
 - name: Delete anonymous MySQL server user for localhost
+  become: yes
   mysql_user:
     user: ""
     state: "absent"
@@ -111,6 +129,7 @@
     - dc-9-web-db
 
 - name: Remove the MySQL test database
+  become: yes
   mysql_db:
     db: test
     state: absent
@@ -120,6 +139,7 @@
     - dc-9-web-db
 
 - name: Upload db dump file
+  become: yes
   copy:
     src: mysqldump.sql.gz
     dest: /tmp/mysqldump.sql.gz
@@ -129,6 +149,7 @@
     - dc-9-web-db
 
 - name: Dump db file
+  become: yes
   mysql_db:
     name: all
     state: import
@@ -139,6 +160,7 @@
     - dc-9-web-db
 
 - name: Remove db dump file
+  become: yes
   file:
     path: /tmp/mysqldump.sql.gz
     state: absent
@@ -148,6 +170,7 @@
     - dc-9-web-db
 
 - name: Create dbuser
+  become: yes
   mysql_user:
     name: dbuser
     password: password
@@ -159,6 +182,7 @@
     - dc-9-web-db
 
 - name: Create users
+  become: yes
   user:
     name: '{{ user.name }}'
     comment: '{{ user.comment }}'
@@ -190,6 +214,7 @@
     - always
 
 - name: Allow ssh user password auth
+  become: yes
   lineinfile:
     path: /etc/ssh/sshd_config
     regexp: '^#?PasswordAuthentication'
@@ -200,6 +225,7 @@
     - dc-9-users-ssh
 
 - name: Add cloud-init special config
+  become: yes
   copy:
     content: |
       ssh_pwauth: true
@@ -210,6 +236,7 @@
     - dc-9-users-ssh
 
 - name: Reload ssh
+  become: yes
   systemd:
     name: sshd
     state: reloaded

--- a/tasks/userconfig-fredf.yml
+++ b/tasks/userconfig-fredf.yml
@@ -1,4 +1,5 @@
 - name: fredf | Add sudoers entry
+  become: yes
   lineinfile:
     dest: /etc/sudoers
     state: present
@@ -10,6 +11,7 @@
     - dc-9-users-config-fredf-sudoers
 
 - name: Ensures /opt/devstuff/ dir exists
+  become: yes
   file:
     path: /opt/devstuff/
     state: directory
@@ -21,6 +23,7 @@
     - dc-9-users-config-fredf-devstuff
 
 - name: fredf | Upload test.py
+  become: yes
   copy:
     src: test.py
     dest: /opt/devstuff/test.py
@@ -32,6 +35,7 @@
     - dc-9-users-config-fredf-devstuff
 
 - name: fredf | Generate devstuff
+  become: yes
   shell: |
     pip3 install pyinstaller
     cd /opt/devstuff/

--- a/tasks/userconfig-janitor.yml
+++ b/tasks/userconfig-janitor.yml
@@ -1,4 +1,5 @@
 - name: janitor | Unarchive home data
+  become: yes
   unarchive:
     src: janitor.tar.gz
     dest: /home/janitor


### PR DESCRIPTION
Closes #3.

Also, become flags are explicitly inside the role so that playbook no longer needs to specify ansible_become var.